### PR TITLE
Add `django.db.backends.postgresql` to postgresql ENGINE matching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install tox
       run: pip install tox
     - name: Style check
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         database: [sqlite, mysql, postgresql]
 
     services:
       mysql:
-        image: mysql:5
+        image: mysql:8
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:
@@ -40,7 +40,7 @@ jobs:
         # needed because the container does not provide a healthcheck
         options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries=5
       postgres:
-        image: postgres:10
+        image: postgres:12-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 .pytest_cache
 .vscode
 /.tox
+*.sqlite3

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@ TEST_CONTAINER := django-dbcleanup-test
 
 .PHONY: style
 style:
-	black --target-version=py36 \
+	black --target-version=py37 \
 	      --line-length=120 \
 		  --skip-string-normalization \
 		  dbcleanup testapp setup.py
 
 .PHONY: style_check
 style_check:
-	black --target-version=py36 \
+	black --target-version=py37 \
 	      --line-length=120 \
 		  --skip-string-normalization \
 		  --check \
@@ -40,7 +40,7 @@ startpg:
 				   --health-interval 10s \
 				   --health-timeout 5s \
 				   --health-retries 5 \
-				   postgres:10
+				   postgres:11-alpine
 	until [ "`docker inspect -f {{.State.Health.Status}} ${TEST_CONTAINER}-pg`" == "healthy" ]; do sleep 0.1; done;
 
 testpg: startpg

--- a/dbcleanup/models.py
+++ b/dbcleanup/models.py
@@ -40,7 +40,10 @@ def _choose_model():
 
         return MySQLTable
 
-    if settings.DATABASES['default']['ENGINE'] == 'django.db.backends.postgresql_psycopg2':
+    if settings.DATABASES['default']['ENGINE'] in (
+        'django.db.backends.postgresql_psycopg2',
+        'django.db.backends.postgresql',
+    ):
         """
         based on https://wiki.postgresql.org/wiki/Disk_Usage
 

--- a/dbcleanup/models.py
+++ b/dbcleanup/models.py
@@ -103,14 +103,21 @@ def _choose_model():
 
         return PGTable
 
+    class TableManager(models.Manager):
+        def get_queryset(self):
+            return super().get_queryset().none()
+
     class NoTable(models.Model):
         """
         bogus to allow projects to run with unsupported DB engines
         (but without any functionality from this app)
         """
 
+        objects = TableManager()
+
         name = models.CharField(max_length=64, primary_key=True)
         rows = models.PositiveBigIntegerField(null=True)
+        size = models.IntegerField(default=0)
 
         class Meta:
             managed = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ include_package_data = True
 packages = find:
 install_requires =
     Django >= 3.0
-python_requires = >=3.6
+python_requires = >=3.7
 
 [options.packages.find]
 exclude =

--- a/testapp/requirements.txt
+++ b/testapp/requirements.txt
@@ -2,6 +2,6 @@
 pytest==6.2.5
 pytest-cov==2.12.1
 pytest-django==4.4.0
-black==20.8b1
+black>=22.0
 mysqlclient==2.0.3
 psycopg2-binary==2.9.2

--- a/testapp/testapp/migrations/0001_initial.py
+++ b/testapp/testapp/migrations/0001_initial.py
@@ -5,7 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/testapp/testapp/migrations/0002_auto_20211014_1519.py
+++ b/testapp/testapp/migrations/0002_auto_20211014_1519.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('testapp', '0001_initial'),
     ]

--- a/testapp/tests/test_admin.py
+++ b/testapp/tests/test_admin.py
@@ -1,0 +1,20 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+
+class Test(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user('tester', 'tester@ppb.it', 'tester')
+
+    def test_changelist(self):
+        """
+        test to make sure that every DB engine allows to *at least* list tables
+        """
+        self.user.is_staff = True
+        self.user.is_superuser = True
+        self.user.save()
+        self.client.force_login(self.user)
+
+        r = self.client.get(reverse('admin:dbcleanup_table_changelist'))
+        self.assertEqual(r.status_code, 200)

--- a/testapp/tests/test_admin.py
+++ b/testapp/tests/test_admin.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 
 class Test(TestCase):
     def setUp(self):
-        self.user = get_user_model().objects.create_user('tester', 'tester@ppb.it', 'tester')
+        self.user = get_user_model().objects.create_user('tester', 'tester@test.it', 'tester')
 
     def test_changelist(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -8,15 +8,15 @@ deps =
     dj22: Django==2.2.*
     dj30: Django==3.0.*
     dj32: Django==3.2.*
-    postgresql: psycopg2-binary
-    mysql: mysqlclient
+    postgresql: psycopg2-binary==2.9.5
+    mysql: mysqlclient==2.1.1
     coverage
 setenv =
     PYTHONPATH = {toxinidir}
     sqlite: DJANGO_SETTINGS_MODULE = testapp.settings
     postgresql: DJANGO_SETTINGS_MODULE = testapp.settings_postgresql
     mysql: DJANGO_SETTINGS_MODULE = testapp.settings_mysql
-whitelist_externals = make
+allowlist_externals = make
 pip_pre = True
 commands = make coverage TEST_ARGS='{posargs:tests}'
 
@@ -30,6 +30,6 @@ skip_install = true
 basepython = python3
 commands = make style_check
 deps =
-    black>=19.10b0
+    black>=22.0
     flake8
 skip_install = true


### PR DESCRIPTION
I was unable to list tables in my app and once I started looking into this, there were 3 different things:

* `NoTable` was not supported in django-admin - an exception was thrown due to non-existing field (`size`)
* After adding `size`, it still wasn't working (maybe it never did?) because it actually tried to query a non-existing table - now added a custom manager to always return `none` queryset
* There's a different ENGINE also supported for psycopg2 and those using it would end up with `NoTable` - added it to the list

Also updated the workflows