### PR TITLE
Test more databases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
-        database: [sqlite, mysql, postgresql]
+        database: [sqlite, mysql, postgresql12, postgres15]
 
     services:
       mysql:
@@ -39,7 +39,17 @@ jobs:
         - 8877:3306
         # needed because the container does not provide a healthcheck
         options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries=5
-      postgres:
+      postgres12:
+        image: postgres:12-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+        - 8878:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      postgres15:
         image: postgres:12-alpine
         env:
           POSTGRES_USER: postgres

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,15 @@
 [tox]
 envlist =
     flake8
-    py{37,38,39}-dj{22,30,32}-{sqlite,postgresql,mysql}
+    py{37,38,39}-dj{22,30,32}-{sqlite,postgresql12,postgresql15,mysql}
 
 [testenv]
 deps =
     dj22: Django==2.2.*
     dj30: Django==3.0.*
     dj32: Django==3.2.*
-    postgresql: psycopg2-binary==2.9.5
+    postgresql12: psycopg2-binary==2.9.5
+    postgresql15: psycopg2-binary==2.9.5
     mysql: mysqlclient==2.1.1
     coverage
 setenv =


### PR DESCRIPTION
Test low and high versions of each database

- (back to) PG10 and PG15
- mysql 5 and 8 (maybe throw MariaDB into the mix)

To check: cross-test each python/django version against only one of the database versions, otherwise matrix will grow too big without any added benefit